### PR TITLE
Allow user to nullify selected value and remove restriction to force select first option for select inputs

### DIFF
--- a/jquery.barrating.js
+++ b/jquery.barrating.js
@@ -40,12 +40,15 @@
                         var val, text, $a, $span;
 
                         val = $(this).val();
-                        text = $(this).text();
-                        $a = $('<a />', { href:'#', 'data-rating-value':val, 'data-rating-text':text });
-                        $span = $('<span />', { text:(userOptions.showValues) ? text : '' });
 
-                        $widget.append($a.append($span));
+                        // For only select inputs - remove force selecting first element
+                        if (($this.is('select') && val > 0) || !$this.is('select')) {
+                            text = $(this).text();
+                            $a = $('<a />', { href:'#', 'data-rating-value':val, 'data-rating-text':text });
+                            $span = $('<span />', { text:(userOptions.showValues) ? text : '' });
 
+                            $widget.append($a.append($span));
+                        }
                     });
 
                     if (userOptions.showSelectedRating) {


### PR DESCRIPTION
Hey,

Please review this PR and let me know if this make sence for you or advice for better solution. If it's OK, I will go ahead and add tests

I use it in survey workflow on the last page. We ask customer to rate a produc. And we want to allow him to change his choise and allow to put 0 in rating from 0 to 5. I don't want to show 0 option as a star, it's weird. This is how it looks now http://i.imm.io/12o54.png When he clicks on selected rating I reset it to zero but don't show zero value(as a star) - second commit here.
