### PR TITLE
syntax error within example in documentation

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -500,7 +500,7 @@ npm install jquery-bar-rating
 <pre>
 <code>
 $('#example').barrating('show', {
-  theme: 'my-awesome-theme'
+  theme: 'my-awesome-theme',
   onSelect: function(value, text, event) {
     if (typeof(event) !== 'undefined') {
       // rating was selected by a user


### PR DESCRIPTION
Missing comma renders the example code unusable.