### PR TITLE
accepts empty string in "set" method.

### DIFF
--- a/jquery.barrating.js
+++ b/jquery.barrating.js
@@ -443,7 +443,7 @@
             this.set = function(value) {
                 var options = getData('userOptions');
 
-                if (!self.$elem.find('option[value="' + value + '"]').val()) return;
+                if (self.$elem.find('option[value="' + value + '"]').length === 0) return;
 
                 // set data
                 setData('ratingValue', value);


### PR DESCRIPTION
"Set" method doesn't accept empty string as the new value because it returns immediately if the option tag has an empty value.
In this patch, the code checks existence of the option tag which has the specified value, even if the value was empty, then reject if the option tag was not found.