### PR TITLE
Added span tag to links when showValues is true.

### DIFF
--- a/jquery.barrating.js
+++ b/jquery.barrating.js
@@ -174,7 +174,10 @@
                             'href': '#',
                             'data-rating-value': val,
                             'data-rating-text': text,
-                            'html': (self.options.showValues) ? text : ''
+                            'html': (self.options.showValues) ? $('<span />', {
+                              'html': text,
+                              'class': 'br-widget-option-label'
+                            }) : ''
                         });
 
                         $w.append($a);


### PR DESCRIPTION
I added a span tag over the values text to get compliance with accessibility requirements. With this, we can display labels always and hide it by CSS if it's required.